### PR TITLE
Replace body _before_ compiling to support selectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ gem "turbolinks"
 gem "angular-turbolinks"
 ```
 
-##### Add angular-turbolinks to your sprockets
+##### Add angular-route and angular-turbolinks to your sprockets
 ```sh
+//= require angular-route
 //= require angular-turbolinks
 ```
 
@@ -24,8 +25,8 @@ app.config([
   }
 ]);
 ```
-##### Add ng-app to the body element (body content will be replaced with a div#turbolinks_content on each page load)
-<body ng-app='myapp'>
+##### Add ng-app to the html element
+<html ng-app='myapp'>
 
 ##### (optional) Broadcast angular $destroy for you to remove any global listeners (window, pending http, etc)
 ```sh
@@ -40,7 +41,6 @@ $(document).on('page:before-change', ->
   * https://github.com/angular/angular.js/issues/2815 (among others)
   * none of the suggested fixes worked for me and this was happening on chrome
 * This approach uses the angular $location/$locationProvider services for click tracking and pushState, steals the $locationChangeStart event and runs the changed url through turbolinks methods
-* instead of re-bootstrapping angular on each new page:load, I found it much more reliable to $compile the body in the response and replace the body contents (assumes body is the ng-app root element)
 * Does not support any of the turbolinks caching
 * Eventually im hoping angular $locationWatch can play nice with external plugins using pushState...
 

--- a/lib/assets/javascripts/angular-turbolinks.js.coffee
+++ b/lib/assets/javascripts/angular-turbolinks.js.coffee
@@ -97,7 +97,10 @@ angular.module('ngTurbolinks', []).run(($location, $rootScope, $http, $q, $compi
 
   changePage = (title, body, csrfToken, runScripts) ->
     document.title = title
-    angular.element("body").html($compile("<div id=\"turbolinks_content\">"+body.innerHTML+"</div>")($rootScope))
+
+    angular.element("body").replaceWith(body)
+    $compile(body)($rootScope)
+
     CSRFToken.update csrfToken if csrfToken?
     executeScriptTags() if runScripts
     currentState = window.history.state


### PR DESCRIPTION
Few changes here:
- replace body before compiling with angular, so global jQuery selectors (#id) work in angular directives
- don't parse html two times, just replace body
- don't introduce new html elements (no #turbolinks_content)
- don't reinstantiate angular application on each request (ng-app in html)

It works like a charm for me.
