### PR TITLE
Fix dependency injection (array format for minification).

### DIFF
--- a/lib/assets/javascripts/angular-turbolinks.js.coffee
+++ b/lib/assets/javascripts/angular-turbolinks.js.coffee
@@ -1,4 +1,4 @@
-angular.module('ngTurbolinks', []).run(($location, $rootScope, $http, $q, $compile)->
+angular.module('ngTurbolinks', []).run(["$location", "$rootScope", "$http", "$q", "$compile", ($location, $rootScope, $http, $q, $compile)->
 
   loadedAssets = null
   createDocument = null
@@ -10,7 +10,7 @@ angular.module('ngTurbolinks', []).run(($location, $rootScope, $http, $q, $compi
     event.data = data if data
     event.initEvent name, true, true
     document.dispatchEvent event
-
+    
   popCookie = (name) ->
     value = document.cookie.match(new RegExp(name+"=(\\w+)"))?[1].toUpperCase() or ''
     document.cookie = name + '=; expires=Thu, 01-Jan-70 00:00:01 GMT; path=/'
@@ -197,4 +197,5 @@ angular.module('ngTurbolinks', []).run(($location, $rootScope, $http, $q, $compi
     
     visit(url)
   )
-)
+
+])


### PR DESCRIPTION
I used this gem for a Rails app. Rails automatically compresses (minifies) assets, which causes problems with AngularJs

> Careful: If you plan to minify your code, your service names will get renamed and break your app.
> (https://docs.angularjs.org/guide/di)

Once the dependencies are listed on the array before the actual function, no problems are perceived.
